### PR TITLE
fix: Ignore Game Masters in raid count and role statistics

### DIFF
--- a/src/mod_boss_announcer.cpp
+++ b/src/mod_boss_announcer.cpp
@@ -176,6 +176,9 @@ public:
             if (!member)
                 continue;
 
+            if (member->IsGameMaster())
+                continue;
+
             if (member->IsAlive())
                 Alive_players++;
 


### PR DESCRIPTION
This PR fixes an issue where the Boss Announcer module was counting Game Masters present inside the raid instance when announcing boss kills.

Closes https://github.com/azerothcore/mod-boss-announcer/issues/2